### PR TITLE
feat: add case insensitive route and path comparison

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,13 @@ export const defaultSchema: PropertiesSchema = {
 export type PageIndexSchema = typeof defaultSchema
 
 export type LyraOptions = Partial<InsertConfig> & {
+	/**
+	 * Controls whether generatedFilePath is filter
+	 * using case sensitive or case insensitive comparison
+	 * @default false
+	 *
+	 */
+	caseSensitive?: boolean
 	pathMatcher: RegExp
 	contentSelectors?: string[]
 	searchOptions?: Omit<SearchParams<PageIndexSchema>, 'term'> | undefined
@@ -60,9 +67,13 @@ const prepareLyraDb = (
 		.map(({ pathname }) => ({
 			pathname,
 			generatedFilePath: routes.filter(
-				(r) =>
-					r.route.replace(/(^\/|\/$)/g, '') ===
-					pathname.replace(/(^\/|\/$)/g, ''),
+				(r) => {
+					const route = r.route.replace(/(^\/|\/$)/g, ''), pathName = pathname.replace(/(^\/|\/$)/g, '')
+					if (dbConfig.caseSensitive) {
+						return route.toLowerCase() === pathName.toLowerCase()
+					}
+					return route === pathName
+				}
 			)[0]?.distURL?.pathname,
 		}))
 		.filter(({ generatedFilePath }) => !!generatedFilePath) as {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,10 +68,13 @@ const prepareLyraDb = (
 			pathname,
 			generatedFilePath: routes.filter(
 				(r) => {
-					const route = r.route.replace(/(^\/|\/$)/g, ''), pathName = pathname.replace(/(^\/|\/$)/g, '')
+					const route = r.route.replace(/(^\/|\/$)/g, '')
+					const pathName = pathname.replace(/(^\/|\/$)/g, '')
+
 					if (dbConfig.caseSensitive) {
 						return route.toLowerCase() === pathName.toLowerCase()
 					}
+
 					return route === pathName
 				}
 			)[0]?.distURL?.pathname,


### PR DESCRIPTION
**Description**
The astro plugin is doing a case sensitive match on route and file paths.

As mentioned by @castarco this makes sense. However, the generated paths from astro's build makes everything lowercase.

This PR is to implement case insensitive matching on the files generated by astro's build and the folder structure being parsed.

Fixes issue https://github.com/LyraSearch/plugin-astro/issues/28
