### PR TITLE
chore: add eslint plugin prettier and rule to prevent one var

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,14 +11,14 @@ module.exports = {
 			`${currentDir}/tsconfig.tests.json`,
 		],
 	},
-	plugins: ['@typescript-eslint'],
+	plugins: ['@typescript-eslint', 'prettier'],
 	extends: [
 		'eslint:recommended',
 		'plugin:@typescript-eslint/eslint-recommended',
 		'plugin:@typescript-eslint/recommended',
 		'plugin:@typescript-eslint/recommended-requiring-type-checking',
 		'plugin:node/recommended-module',
-		'prettier',
+		"plugin:prettier/recommended",
 	],
 	rules: {
 		'node/no-missing-import': [
@@ -33,6 +33,7 @@ module.exports = {
 				tryExtensions: ['.cts', '.mts', '.ts', '.d.ts'],
 			},
 		],
+		'one-var': ['error', 'never'],
 		quotes: ['error', 'single', { avoidEscape: true }],
 		'sort-imports': 'error',
 	},

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,18 +66,16 @@ const prepareLyraDb = (
 		.filter(({ pathname }) => dbConfig.pathMatcher.test(pathname))
 		.map(({ pathname }) => ({
 			pathname,
-			generatedFilePath: routes.filter(
-				(r) => {
-					const route = r.route.replace(/(^\/|\/$)/g, '')
-					const pathName = pathname.replace(/(^\/|\/$)/g, '')
+			generatedFilePath: routes.filter((r) => {
+				const route = r.route.replace(/(^\/|\/$)/g, '')
+				const pathName = pathname.replace(/(^\/|\/$)/g, '')
 
-					if (dbConfig.caseSensitive) {
-						return route.toLowerCase() === pathName.toLowerCase()
-					}
-
-					return route === pathName
+				if (dbConfig.caseSensitive) {
+					return route.toLowerCase() === pathName.toLowerCase()
 				}
-			)[0]?.distURL?.pathname,
+
+				return route === pathName
+			})[0]?.distURL?.pathname,
 		}))
 		.filter(({ generatedFilePath }) => !!generatedFilePath) as {
 		pathname: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,6 +1683,13 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
+eslint-plugin-prettier@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
+  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -1878,6 +1885,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
@@ -3520,6 +3532,13 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier-plugin-astro@^0.5.3:
   version "0.5.5"


### PR DESCRIPTION
**Description**
This is a PR to make eslint and prettier work better together.

The goal is to have prettier and eslint show errors and in the developer's editor.

This is following the `eslint-plugin-prettier` [README](https://github.com/prettier/eslint-plugin-prettier) to setup the plugin.

**How to test**
1. In your IDE (I use vscode), try to chain create const like so `const foo = 'bar', baz: 'foo'`
2. Confirm you see an eslint message like the following

![Screenshot from 2022-12-24 07-34-07](https://user-images.githubusercontent.com/6714127/209403274-16ca15ba-cd8c-4f32-b0ba-dc6b802ca402.png)

3. After saving your file, confirm it fixes (if you have this enabled in your IDE) like so

![Screenshot from 2022-12-24 07-35-04](https://user-images.githubusercontent.com/6714127/209403348-4802b225-3daa-4ceb-8a07-ce24183a2cf3.png)
