### PR TITLE
fix(#46): add pnpm as a dev deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ dist/
 node_modules/
 test/sandbox/dist
 test/sandbox/node_modules
+test/sandbox/*-lock.json
+test/sandbox/yarn.lock
 pnpm-lock.yaml
 yarn.lock

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm test
+# Using npm here because it ships with node be default
+npm run test

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-promise": "^6.1.1",
+    "pnpm": "^7.27.0",
     "prettier": "^2.7.1",
     "tap-mocha-reporter": "^5.0.3",
     "tsx": "^3.12.2",


### PR DESCRIPTION
- git hooks and tests making use of pnpm but other contributors might now have pnpm
- adding as a dev deps to the repo so all is well
- Also used `npm` in the pre-commit hooks as it ships with node